### PR TITLE
Pass options to server.authorize, server.authenticate, and server.token

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function ExpressOAuthServer(options) {
  * (See: https://tools.ietf.org/html/rfc6749#section-7)
  */
 
-ExpressOAuthServer.prototype.authenticate = function() {
+ExpressOAuthServer.prototype.authenticate = function(options) {
   var server = this.server;
 
   return function(req, res, next) {
@@ -41,7 +41,7 @@ ExpressOAuthServer.prototype.authenticate = function() {
 
     return Promise.bind(this)
       .then(function() {
-        return server.authenticate(request, response);
+        return server.authenticate(request, response, options);
       })
       .tap(function(token) {
         res.locals.oauth = { token: token };
@@ -61,7 +61,7 @@ ExpressOAuthServer.prototype.authenticate = function() {
  * (See: https://tools.ietf.org/html/rfc6749#section-3.1)
  */
 
-ExpressOAuthServer.prototype.authorize = function() {
+ExpressOAuthServer.prototype.authorize = function(options) {
   var server = this.server;
 
   return function(req, res, next) {
@@ -70,7 +70,7 @@ ExpressOAuthServer.prototype.authorize = function() {
 
     return Promise.bind(this)
       .then(function() {
-        return server.authorize(request, response);
+        return server.authorize(request, response, options);
       })
       .tap(function(code) {
         res.locals.oauth = { code: code };
@@ -93,7 +93,7 @@ ExpressOAuthServer.prototype.authorize = function() {
  * (See: https://tools.ietf.org/html/rfc6749#section-3.2)
  */
 
-ExpressOAuthServer.prototype.token = function() {
+ExpressOAuthServer.prototype.token = function(options) {
   var server = this.server;
 
   return function(req, res, next) {
@@ -102,7 +102,7 @@ ExpressOAuthServer.prototype.token = function() {
 
     return Promise.bind(this)
       .then(function() {
-        return server.token(request, response);
+        return server.token(request, response, options);
       })
       .tap(function(token) {
         res.locals.oauth = { token: token };

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -9,6 +9,7 @@ var Response = require('oauth2-server').Response;
 var express = require('express');
 var request = require('supertest');
 var sinon = require('sinon');
+var should = require('should');
 
 /**
  * Test `ExpressOAuthServer`.
@@ -33,9 +34,31 @@ describe('ExpressOAuthServer', function() {
         .get('/')
         .end(function() {
           oauth.server.authenticate.callCount.should.equal(1);
-          oauth.server.authenticate.firstCall.args.should.have.length(2);
+          oauth.server.authenticate.firstCall.args.should.have.length(3);
           oauth.server.authenticate.firstCall.args[0].should.be.an.instanceOf(Request);
           oauth.server.authenticate.firstCall.args[1].should.be.an.instanceOf(Response);
+          should.not.exist(oauth.server.authenticate.firstCall.args[2])
+          oauth.server.authenticate.restore();
+
+          done();
+        });
+    });
+
+    it('should call `authenticate()` with options', function(done) {
+      var oauth = new ExpressOAuthServer({ model: {} });
+
+      sinon.stub(oauth.server, 'authenticate').returns({});
+
+      app.use(oauth.authenticate({options: true}));
+
+      request(app.listen())
+        .get('/')
+        .end(function() {
+          oauth.server.authenticate.callCount.should.equal(1);
+          oauth.server.authenticate.firstCall.args.should.have.length(3);
+          oauth.server.authenticate.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.authenticate.firstCall.args[1].should.be.an.instanceOf(Response);
+          oauth.server.authenticate.firstCall.args[2].should.eql({options: true});
           oauth.server.authenticate.restore();
 
           done();
@@ -55,9 +78,31 @@ describe('ExpressOAuthServer', function() {
         .get('/')
         .end(function() {
           oauth.server.authorize.callCount.should.equal(1);
-          oauth.server.authorize.firstCall.args.should.have.length(2);
+          oauth.server.authorize.firstCall.args.should.have.length(3);
           oauth.server.authorize.firstCall.args[0].should.be.an.instanceOf(Request);
           oauth.server.authorize.firstCall.args[1].should.be.an.instanceOf(Response);
+          should.not.exist(oauth.server.authorize.firstCall.args[2]);
+          oauth.server.authorize.restore();
+
+          done();
+        });
+    });
+
+    it('should call `authorize()` with options', function(done) {
+      var oauth = new ExpressOAuthServer({ model: {} });
+
+      sinon.stub(oauth.server, 'authorize').returns({});
+
+      app.use(oauth.authorize({options: true}));
+
+      request(app.listen())
+        .get('/')
+        .end(function() {
+          oauth.server.authorize.callCount.should.equal(1);
+          oauth.server.authorize.firstCall.args.should.have.length(3);
+          oauth.server.authorize.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.authorize.firstCall.args[1].should.be.an.instanceOf(Response);
+          oauth.server.authorize.firstCall.args[2].should.eql({options: true});
           oauth.server.authorize.restore();
 
           done();
@@ -77,9 +122,31 @@ describe('ExpressOAuthServer', function() {
         .get('/')
         .end(function() {
           oauth.server.token.callCount.should.equal(1);
-          oauth.server.token.firstCall.args.should.have.length(2);
+          oauth.server.token.firstCall.args.should.have.length(3);
           oauth.server.token.firstCall.args[0].should.be.an.instanceOf(Request);
           oauth.server.token.firstCall.args[1].should.be.an.instanceOf(Response);
+          should.not.exist(oauth.server.token.firstCall.args[2]);
+          oauth.server.token.restore();
+
+          done();
+        });
+    });
+
+    it('should call `token()` with options', function(done) {
+      var oauth = new ExpressOAuthServer({ model: {} });
+
+      sinon.stub(oauth.server, 'token').returns({});
+
+      app.use(oauth.token({options: true}));
+
+      request(app.listen())
+        .get('/')
+        .end(function() {
+          oauth.server.token.callCount.should.equal(1);
+          oauth.server.token.firstCall.args.should.have.length(3);
+          oauth.server.token.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.token.firstCall.args[1].should.be.an.instanceOf(Response);
+          oauth.server.token.firstCall.args[2].should.eql({options: true});
           oauth.server.token.restore();
 
           done();


### PR DESCRIPTION
Allow passing of options object to server.authorize, server.authenticate, and server.token