### PR TITLE
Use error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,15 +37,15 @@ function ExpressOAuthServer(options) {
  */
 
 ExpressOAuthServer.prototype.authenticate = function(options) {
-  var server = this.server;
+  var that = this;
 
   return function(req, res, next) {
     var request = new Request(req);
     var response = new Response(res);
 
-    return Promise.bind(this)
+    return Promise.bind(that)
       .then(function() {
-        return server.authenticate(request, response, options);
+        return this.server.authenticate(request, response, options);
       })
       .tap(function(token) {
         res.locals.oauth = { token: token };
@@ -66,15 +66,15 @@ ExpressOAuthServer.prototype.authenticate = function(options) {
  */
 
 ExpressOAuthServer.prototype.authorize = function(options) {
-  var server = this.server;
+  var that = this;
 
   return function(req, res, next) {
     var request = new Request(req);
     var response = new Response(res);
 
-    return Promise.bind(this)
+    return Promise.bind(that)
       .then(function() {
-        return server.authorize(request, response, options);
+        return this.server.authorize(request, response, options);
       })
       .tap(function(code) {
         res.locals.oauth = { code: code };
@@ -97,15 +97,15 @@ ExpressOAuthServer.prototype.authorize = function(options) {
  */
 
 ExpressOAuthServer.prototype.token = function(options) {
-  var server = this.server;
+  var that = this;
 
   return function(req, res, next) {
     var request = new Request(req);
     var response = new Response(res);
 
-    return Promise.bind(this)
+    return Promise.bind(that)
       .then(function() {
-        return server.token(request, response, options);
+        return this.server.token(request, response, options);
       })
       .tap(function(token) {
         res.locals.oauth = { token: token };

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ ExpressOAuthServer.prototype.authenticate = function(options) {
       })
       .catch(function(e) {
         return handleError.call(this, e, req, res, null, next);
-    });
+      });
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ ExpressOAuthServer.prototype.authenticate = function(options) {
         next();
       })
       .catch(function(e) {
-        return handleError(e, req, res, null, next);
+        return handleError.call(this, e, req, res, null, next);
     });
   };
 };
@@ -80,10 +80,10 @@ ExpressOAuthServer.prototype.authorize = function(options) {
         res.locals.oauth = { code: code };
       })
       .then(function() {
-        return handleResponse(req, res, response);
+        return handleResponse.call(this, req, res, response);
       })
       .catch(function(e) {
-        return handleError(e, req, res, response, next);
+        return handleError.call(this, e, req, res, response, next);
       });
   };
 };
@@ -111,10 +111,10 @@ ExpressOAuthServer.prototype.token = function(options) {
         res.locals.oauth = { token: token };
       })
       .then(function() {
-        return handleResponse(req, res, response);
+        return handleResponse.call(this, req, res, response);
       })
       .catch(function(e) {
-        return handleError(e, req, res, response, next);
+        return handleError.call(this, e, req, res, response, next);
       });
   };
 };
@@ -141,11 +141,13 @@ var handleError = function(e, req, res, response, next) {
       res.set(response.headers);
     }
 
+    res.status(e.code);
+
     if (e instanceof UnauthorizedRequestError) {
-      return res.status(e.code);
+      return res.send();
     }
 
-    res.status(e.code).send({ error: e.name, error_description: e.message });
+    res.send({ error: e.name, error_description: e.message });
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ function ExpressOAuthServer(options) {
     throw new InvalidArgumentError('Missing parameter: `model`');
   }
 
+  this.useErrorHandler = options.useErrorHandler ? true : false;
+  delete options.useErrorHandler;
+
   this.server = new NodeOAuthServer(options);
 }
 
@@ -49,8 +52,8 @@ ExpressOAuthServer.prototype.authenticate = function(options) {
         next();
       })
       .catch(function(e) {
-        return handleError(e, req, res);
-      });
+        return handleError(e, req, res, null, next);
+    });
   };
 };
 
@@ -80,7 +83,7 @@ ExpressOAuthServer.prototype.authorize = function(options) {
         return handleResponse(req, res, response);
       })
       .catch(function(e) {
-        return handleError(e, req, res, response);
+        return handleError(e, req, res, response, next);
       });
   };
 };
@@ -111,7 +114,7 @@ ExpressOAuthServer.prototype.token = function(options) {
         return handleResponse(req, res, response);
       })
       .catch(function(e) {
-        return handleError(e, req, res, response);
+        return handleError(e, req, res, response, next);
       });
   };
 };
@@ -129,17 +132,21 @@ var handleResponse = function(req, res, response) {
  * Handle error.
  */
 
-var handleError = function(e, req, res, response) {
+var handleError = function(e, req, res, response, next) {
 
-  if (response) {
-    res.set(response.headers);
+  if (this.useErrorHandler === true) {
+    next(e);
+  } else {
+    if (response) {
+      res.set(response.headers);
+    }
+
+    if (e instanceof UnauthorizedRequestError) {
+      return res.status(e.code);
+    }
+
+    res.status(e.code).send({ error: e.name, error_description: e.message });
   }
-
-  if (e instanceof UnauthorizedRequestError) {
-    return res.status(e.code);
-  }
-
-  res.status(e.code).send({ error: e.name, error_description: e.message });
 };
 
 /**


### PR DESCRIPTION
Add a new option, `useErrorHandler` which will invoke `next(err)` if set to true on any errors.  If not set or set to false, the library will continue to send the response.  
