### PR TITLE
Add option to continue middleware execution

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,3 +34,28 @@ app.use(function(req, res) {
 
 app.listen(3000);
 ```
+
+## Options
+
+```
+var options = { 
+  useErrorHandler: false, 
+  continueMiddleWare: false,
+}
+```
+* `useErrorHandler`
+(_type: boolean_ default: false)
+
+  If false, an error response will be rendered by this component.
+  Set this value to true to allow your own express error handler to handle the error.
+
+* `continueMiddleware`
+(_type: boolean default: false_)
+
+  The `authorize()` and `token()` middlewares will both render their 
+  result to the response and end the pipeline.
+  next() will only be called if this is set to true.
+
+  **Note:** You cannot modify the response since the headers have already been sent.
+
+  `authenticate()` does not modify the response and will always call next()

--- a/index.js
+++ b/index.js
@@ -25,6 +25,9 @@ function ExpressOAuthServer(options) {
   this.useErrorHandler = options.useErrorHandler ? true : false;
   delete options.useErrorHandler;
 
+  this.continueMiddleware = options.continueMiddleware ? true : false;
+  delete options.continueMiddleware;
+
   this.server = new NodeOAuthServer(options);
 }
 
@@ -78,6 +81,9 @@ ExpressOAuthServer.prototype.authorize = function(options) {
       })
       .tap(function(code) {
         res.locals.oauth = { code: code };
+        if (this.continueMiddleware) {
+          next();
+        }
       })
       .then(function() {
         return handleResponse.call(this, req, res, response);
@@ -109,6 +115,9 @@ ExpressOAuthServer.prototype.token = function(options) {
       })
       .tap(function(token) {
         res.locals.oauth = { token: token };
+        if (this.continueMiddleware) {
+          next();
+        }
       })
       .then(function() {
         return handleResponse.call(this, req, res, response);

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -67,7 +67,7 @@ describe('ExpressOAuthServer', function() {
   });
 
   describe('authorize()', function() {
-    it('should call `authorize() and end middleware execution`', function(done) {
+    it('should call `authorize()` and end middleware execution', function(done) {
       var nextMiddleware = sinon.spy()
       var oauth = new ExpressOAuthServer({ model: {} });
 
@@ -90,7 +90,7 @@ describe('ExpressOAuthServer', function() {
         });
     });
 
-    it('should call `authorize() and continue middleware chain`', function(done) {
+    it('should call `authorize()` and continue middleware chain', function(done) {
       var nextMiddleware = sinon.spy()
       var oauth = new ExpressOAuthServer({ model: {}, continueMiddleware: true });
 
@@ -136,7 +136,7 @@ describe('ExpressOAuthServer', function() {
   });
 
   describe('token()', function() {
-    it('should call `token() and end middleware chain`', function(done) {
+    it('should call `token()` and end middleware chain', function(done) {
       var nextMiddleware = sinon.spy()
       var oauth = new ExpressOAuthServer({ model: {} });
 
@@ -159,7 +159,7 @@ describe('ExpressOAuthServer', function() {
         });
     });
 
-    it('should call `token() and continue middleware chain`', function(done) {
+    it('should call `token()` and continue middleware chain', function(done) {
       var nextMiddleware = sinon.spy()
       var oauth = new ExpressOAuthServer({ model: {}, continueMiddleware: true });
 

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -61,19 +61,20 @@ describe('ExpressOAuthServer', function() {
           oauth.server.authenticate.firstCall.args[1].should.be.an.instanceOf(Response);
           oauth.server.authenticate.firstCall.args[2].should.eql({options: true});
           oauth.server.authenticate.restore();
-
           done();
         });
     });
   });
 
   describe('authorize()', function() {
-    it('should call `authorize()`', function(done) {
+    it('should call `authorize() and end middleware execution`', function(done) {
+      var nextMiddleware = sinon.spy()
       var oauth = new ExpressOAuthServer({ model: {} });
 
       sinon.stub(oauth.server, 'authorize').returns({});
 
       app.use(oauth.authorize());
+      app.use(nextMiddleware);
 
       request(app.listen())
         .get('/')
@@ -84,7 +85,31 @@ describe('ExpressOAuthServer', function() {
           oauth.server.authorize.firstCall.args[1].should.be.an.instanceOf(Response);
           should.not.exist(oauth.server.authorize.firstCall.args[2]);
           oauth.server.authorize.restore();
+          nextMiddleware.called.should.be.false();
+          done();
+        });
+    });
 
+    it('should call `authorize() and continue middleware chain`', function(done) {
+      var nextMiddleware = sinon.spy()
+      var oauth = new ExpressOAuthServer({ model: {}, continueMiddleware: true });
+
+      sinon.stub(oauth.server, 'authorize').returns({});
+
+      app.use(oauth.authorize());
+      app.use(nextMiddleware);
+
+      request(app.listen())
+        .get('/')
+        .end(function() {
+          oauth.server.authorize.callCount.should.equal(1);
+          oauth.server.authorize.firstCall.args.should.have.length(3);
+          oauth.server.authorize.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.authorize.firstCall.args[1].should.be.an.instanceOf(Response);
+          should.not.exist(oauth.server.authorize.firstCall.args[2]);
+          oauth.server.authorize.restore();
+          nextMiddleware.called.should.be.true();
+          nextMiddleware.args[0].length.should.eql(3);
           done();
         });
     });
@@ -105,19 +130,20 @@ describe('ExpressOAuthServer', function() {
           oauth.server.authorize.firstCall.args[1].should.be.an.instanceOf(Response);
           oauth.server.authorize.firstCall.args[2].should.eql({options: true});
           oauth.server.authorize.restore();
-
           done();
         });
     });
   });
 
   describe('token()', function() {
-    it('should call `token()`', function(done) {
+    it('should call `token() and end middleware chain`', function(done) {
+      var nextMiddleware = sinon.spy()
       var oauth = new ExpressOAuthServer({ model: {} });
 
       sinon.stub(oauth.server, 'token').returns({});
 
       app.use(oauth.token());
+      app.use(nextMiddleware);
 
       request(app.listen())
         .get('/')
@@ -128,7 +154,31 @@ describe('ExpressOAuthServer', function() {
           oauth.server.token.firstCall.args[1].should.be.an.instanceOf(Response);
           should.not.exist(oauth.server.token.firstCall.args[2]);
           oauth.server.token.restore();
+          nextMiddleware.called.should.be.false();
+          done();
+        });
+    });
 
+    it('should call `token() and continue middleware chain`', function(done) {
+      var nextMiddleware = sinon.spy()
+      var oauth = new ExpressOAuthServer({ model: {}, continueMiddleware: true });
+
+      sinon.stub(oauth.server, 'token').returns({});
+
+      app.use(oauth.token());
+      app.use(nextMiddleware);
+
+      request(app.listen())
+        .get('/')
+        .end(function() {
+          oauth.server.token.callCount.should.equal(1);
+          oauth.server.token.firstCall.args.should.have.length(3);
+          oauth.server.token.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.token.firstCall.args[1].should.be.an.instanceOf(Response);
+          should.not.exist(oauth.server.token.firstCall.args[2]);
+          oauth.server.token.restore();
+          nextMiddleware.called.should.be.true();
+          nextMiddleware.args[0].length.should.eql(3);
           done();
         });
     });
@@ -149,7 +199,6 @@ describe('ExpressOAuthServer', function() {
           oauth.server.token.firstCall.args[1].should.be.an.instanceOf(Response);
           oauth.server.token.firstCall.args[2].should.eql({options: true});
           oauth.server.token.restore();
-
           done();
         });
     });


### PR DESCRIPTION
Our integration uses some middleware functions to do additional stats collection after the authorize() and token() responses have been sent.  This PR adds an option to allow the calling of next() after the response.send() calls.

It also fixes some tests that had assertions in middleware that was not being executed.