### PR TITLE
Added the ability to continue without a token

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ ExpressOAuthServer.prototype.authenticate = function(options) {
         return this.server.authenticate(new Request(request), new Response(response), options);
       })
       .tap(function(token) {
-        response.oauth = { token: token };
+        request.oauth = { token: token };
         return next();
       })
       .catch(function(error) {

--- a/index.js
+++ b/index.js
@@ -40,22 +40,28 @@ function ExpressOAuthServer(options) {
  */
 
 ExpressOAuthServer.prototype.authenticate = function(options) {
-  var that = this;
+  const self = this;
+  options = options || {};
 
-  return function(req, res, next) {
-    var request = new Request(req);
-    var response = new Response(res);
-
-    return Promise.bind(that)
+  return function(request, response, next) {
+    return Promise.bind(self)
       .then(function() {
-        return this.server.authenticate(request, response, options);
+        return this.server.authenticate(new Request(request), new Response(response), options);
       })
       .tap(function(token) {
-        res.locals.oauth = { token: token };
-        next();
+        _.extend(response.context, {
+          oauth: {
+            token
+          }
+        });
+        return next();
       })
-      .catch(function(e) {
-        return handleError.call(this, e, req, res, null, next);
+      .catch(function(error) {
+        if (typeof options.catchErrorAndContinue !== 'undefined' && options.catchErrorAndContinue) {
+          return next();
+        } else {
+          return handleError.call(this, error, request, response, null, next);
+        }
       });
   };
 };

--- a/index.js
+++ b/index.js
@@ -49,11 +49,7 @@ ExpressOAuthServer.prototype.authenticate = function(options) {
         return this.server.authenticate(new Request(request), new Response(response), options);
       })
       .tap(function(token) {
-        _.extend(response.context, {
-          oauth: {
-            token
-          }
-        });
+        response.oauth = { token: token };
         return next();
       })
       .catch(function(error) {


### PR DESCRIPTION
Here at Concept Gaming, we're implementing GraphQL. The setup makes things difficult to work with as GraphQL only exposes data through the use of a single route, this requires us to explicitly check specific end points. I'd greatly appreciate it if this could be merged rather than having us to re-implement it in our application.