### PR TITLE
Fix secondary error when handing errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,9 @@ var handleError = function(e, req, res, response, next) {
       res.set(response.headers);
     }
 
-    res.status(e.code);
+    if (e.code) {
+      res.status(e.code);
+    }
 
     if (e instanceof UnauthorizedRequestError) {
       return res.send();


### PR DESCRIPTION
Not all errors are guaranteed to have a code. Setting status to an undefined code is itself another error which masks the original error.