### PR TITLE
add oauth response under continueMiddleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ ExpressOAuthServer.prototype.authorize = function(options) {
       .tap(function(code) {
         res.locals.oauth = { code: code };
         if (this.continueMiddleware) {
+          res.locals.oauth.response = response;
           next();
         }
       })
@@ -115,6 +116,7 @@ ExpressOAuthServer.prototype.token = function(options) {
       .tap(function(token) {
         res.locals.oauth = { token: token };
         if (this.continueMiddleware) {
+          res.locals.oauth.response = response;
           next();
         }
       })


### PR DESCRIPTION
Adds the oauth server response to the res.locals.oauth object when the continueMiddleware option is used. This will allow simple overrides that require continueMiddleware to still have access to the response that was worked on, allowing the developer to use functions similar to the handleResponse to quickly build the express response.