### PR TITLE
Example code doesn't work as is

### DIFF
--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -17,7 +17,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
 // Add OAuth server.
-app.oauth = oauthServer({
+app.oauth = new oauthServer({
   model: require('./model')
 });
 


### PR DESCRIPTION
## Issue
Update example code to work this seems to be a duplicate of https://github.com/oauthjs/express-oauth-server/pull/75 probably just consider that PR instead of this one.

## Error
```
/home/node/app/node_modules/express-oauth-server/index.js:25
this.useErrorHandler = options.useErrorHandler ? true : false;
                                    ^

TypeError: Cannot set property 'useErrorHandler' of undefined
    at ExpressOAuthServer (/home/node/app/node_modules/express-oauth-server/index.js:25:24)
    at Object.<anonymous> (/home/node/app/index.js:14:13)
    at Module._compile (internal/modules/cjs/loader.js:1076:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:941:32)
    at Function.Module._load (internal/modules/cjs/loader.js:782:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
```

## Fix
In order to fix this example adding new to the oauthServer call allows the use of this within the constructor.